### PR TITLE
Add a publish/subscribe mechanism

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,8 @@
 
 {deps, [
   {metal,
-    {git, "http://github.com/lpgauth/metal.git", {tag, "0.1.0"}}}
+    {git, "http://github.com/lpgauth/metal.git", {tag, "0.1.0"}}},
+  {gproc, "0.9.0"}
 ]}.
 
 {edoc_opts, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,12 @@
-[{<<"metal">>,
+{"1.2.0",
+[{<<"gproc">>,{pkg,<<"gproc">>,<<"0.9.0">>},0},
+ {<<"metal">>,
   {git,"http://github.com/lpgauth/metal.git",
        {ref,"bbc3f9fa3fa83fa138096234e79ecb61265cadf5"}},
-  0}].
+  0}]}.
+[
+{pkg_hash,[
+ {<<"gproc">>, <<"853CCB7805E9ADA25D227A157BA966F7B34508F386A3E7E21992B1B484230699">>}]},
+{pkg_hash_ext,[
+ {<<"gproc">>, <<"587E8AF698CCD3504CF4BA8D90F893EDE2B0F58CABB8A916E2BF9321DE3CF10B">>}]}
+].

--- a/src/rig.app.src
+++ b/src/rig.app.src
@@ -1,12 +1,13 @@
 {application, rig, [
-  {description, "config manager"},
-  {vsn, "1.0.1"},
-  {registered, []},
-  {applications, [
-    kernel,
-    stdlib,
-    metal
-  ]},
-  {mod, {rig_app, []}},
-  {env, []}
+    {description, "config manager"},
+    {vsn, "1.0.1"},
+    {registered, []},
+    {applications, [
+        kernel,
+        stdlib,
+        metal,
+        gproc
+    ]},
+    {mod, {rig_app, []}},
+    {env, []}
 ]}.

--- a/src/rig_events.erl
+++ b/src/rig_events.erl
@@ -34,7 +34,12 @@ publish(Name, Event) ->
 -spec subscribe(Name :: atom()) -> ok | {ok, MostRecentEvent :: term()}.
 subscribe(Name) ->
     gproc:reg(?TOPIC(Name)),
-    gen_server:call(?MODULE, {fetch, Name}).
+    try
+        gen_server:call(?MODULE, {fetch, Name})
+    catch
+        _:_:_ ->
+            ok
+    end.
 
 init([]) ->
     {ok, #state{}}.

--- a/src/rig_events.erl
+++ b/src/rig_events.erl
@@ -1,17 +1,58 @@
 -module(rig_events).
 
+-behaviour(gen_server).
+
 %% API
 -export([
+    start_link/0,
     publish/2,
     subscribe/1
 ]).
 
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
 -define(TOPIC(Name), {p, l, {?MODULE, Name}}).
 
--spec publish(Name :: atom(), Data :: term()) -> ok.
-publish(Name, Data) ->
-    gproc:send(?TOPIC(Name), Data).
+-record(state, {cache = #{} :: map()}).
 
--spec subscribe(Name :: atom()) -> ok.
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec publish(Name :: atom(), Event :: term()) -> ok.
+publish(Name, Event) ->
+    gproc:send(?TOPIC(Name), Event),
+    gen_server:cast(?MODULE, {save, Name, Event}).
+
+-spec subscribe(Name :: atom()) -> ok | {ok, MostRecentEvent :: term()}.
 subscribe(Name) ->
-    gproc:reg(?TOPIC(Name)).
+    gproc:reg(?TOPIC(Name)),
+    gen_server:call(?MODULE, {fetch, Name}).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call({fetch, Name}, _From, State) ->
+    Reply =
+        case maps:find(Name, State#state.cache) of
+            error -> ok;
+            {ok, Value} -> {ok, Value}
+        end,
+    {reply, Reply, State}.
+
+handle_cast({save, Name, Event}, State = #state{cache = Cache}) ->
+    WithNewEvent = Cache#{Name => Event},
+    {noreply, State#state{cache = WithNewEvent}}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.

--- a/src/rig_events.erl
+++ b/src/rig_events.erl
@@ -1,0 +1,17 @@
+-module(rig_events).
+
+%% API
+-export([
+    publish/2,
+    subscribe/1
+]).
+
+-define(TOPIC(Name), {p, l, {?MODULE, Name}}).
+
+-spec publish(Name :: atom(), Data :: term()) -> ok.
+publish(Name, Data) ->
+    gproc:send(?TOPIC(Name), Data).
+
+-spec subscribe(Name :: atom()) -> ok.
+subscribe(Name) ->
+    gproc:reg(?TOPIC(Name)).

--- a/src/rig_persist.erl
+++ b/src/rig_persist.erl
@@ -38,7 +38,12 @@ start_link() ->
 init([]) ->
     case application:get_env(?APP, persist_topic) of
         {ok, Topic} ->
-            rig_events:subscribe(Topic);
+            case rig_events:subscribe(Topic) of
+                {ok, Event} ->
+                    self() ! Event;
+                ok ->
+                    ok
+            end;
         _ ->
             ok
     end,

--- a/src/rig_persist.erl
+++ b/src/rig_persist.erl
@@ -35,7 +35,7 @@ start_link() ->
 
 % Callbacks
 -spec init([atom()]) -> {ok, term()}.
-init([Topic]) ->
+init([]) ->
     case application:get(?APP, persist_topic) of
         {ok, Topic} ->
             rig_events:subscribe(Topic);

--- a/src/rig_persist.erl
+++ b/src/rig_persist.erl
@@ -16,8 +16,14 @@
 % API
 -export([start_link/0]).
 % Callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
-         code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
 -record(state, {}).
 
@@ -28,9 +34,15 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 % Callbacks
--spec init([]) -> {ok, term()}.
-init(_Args) ->
-    error_logger : info_msg( "rig_persist reporting to work"),
+-spec init([atom()]) -> {ok, term()}.
+init([Topic]) ->
+    case application:get(?APP, persist_topic) of
+        {ok, Topic} ->
+            rig_events:subscribe(Topic);
+        _ ->
+            ok
+    end,
+    error_logger:info_msg("rig_persist reporting to work"),
     {ok, #state{}}.
 
 -spec handle_call(term(), pid(), term()) -> {ok, term()}.
@@ -47,17 +59,16 @@ handle_info({rig_index, update, Table}, State) ->
     {ok, Records} = rig:all(Table),
     rig_persist_utils:to_persistent_term(Records),
     Then = erlang:system_time(millisecond),
-    error_logger : info_msg( "persisted in ~p millsecs" , [ Then - Now ] ),
+    error_logger:info_msg("persisted in ~p millsecs", [Then - Now]),
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 
 -spec terminate(term(), term()) -> term().
 terminate(Reason, _State) ->
-    error_logger : info_msg( "rig_persist terminating with Reason: ~p~n",[Reason]),
+    error_logger:info_msg("rig_persist terminating with Reason: ~p~n", [Reason]),
     ok.
 
 -spec code_change(term(), term(), term()) -> {ok, term()}.
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-

--- a/src/rig_persist.erl
+++ b/src/rig_persist.erl
@@ -36,7 +36,7 @@ start_link() ->
 % Callbacks
 -spec init([atom()]) -> {ok, term()}.
 init([]) ->
-    case application:get(?APP, persist_topic) of
+    case application:get_env(?APP, persist_topic) of
         {ok, Topic} ->
             rig_events:subscribe(Topic);
         _ ->

--- a/src/rig_server.erl
+++ b/src/rig_server.erl
@@ -174,6 +174,7 @@ reload({Name, Filename, DecoderFun, Opts}, Current, New) ->
         ok = rig_index:add(Name, New),
         Subscribers = ?LOOKUP(subscribers, Opts, ?DEFAULT_SUBSCRIBERS),
         [Pid ! {rig_index, update, Name} || Pid <- Subscribers],
+        rig_events:publish(Name, {rig_index, update, Name}),
         cleanup_table(Current),
         Diff = timer:now_diff(os:timestamp(), Timestamp) div 1000,
         error_logger:info_msg("~p config reloaded in ~p ms", [Name, Diff])

--- a/src/rig_sup.erl
+++ b/src/rig_sup.erl
@@ -24,4 +24,4 @@ start_link() ->
 init([]) ->
     rig_index:init(),
     
-    {ok, {{one_for_one, 5, 10}, [?SUP_CHILD(rig_persist_sup),?CHILD(?SERVER)]}}.
+    {ok, {{one_for_one, 5, 10}, [?SUP_CHILD(rig_persist_sup), ?CHILD(?SERVER), ?CHILD(rig_events)]}}.

--- a/src/rig_sup.erl
+++ b/src/rig_sup.erl
@@ -24,4 +24,4 @@ start_link() ->
 init([]) ->
     rig_index:init(),
     
-    {ok, {{one_for_one, 5, 10}, [?SUP_CHILD(rig_persist_sup), ?CHILD(?SERVER), ?CHILD(rig_events)]}}.
+    {ok, {{one_for_one, 5, 10}, [?CHILD(rig_events), ?SUP_CHILD(rig_persist_sup), ?CHILD(?SERVER)]}}.


### PR DESCRIPTION
Currently, the `listeners` feature is kind of broken because, if you depend on the application, the application will get booted before the listeners are started and it will crash once the message are being sent (since the listeners are not yet spawned). This PR adds a way to subscribe to specific topics once you booted instead of specifying it inside the configuration.